### PR TITLE
Enable pipenv in S2I

### DIFF
--- a/.s2i/environment
+++ b/.s2i/environment
@@ -1,0 +1,1 @@
+ENABLE_PIPENV=true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
--i https://pypi.org/simple
-certifi==2018.8.24
-chardet==3.0.4
-idna==2.7
-kafka-python==1.4.3
-requests==2.19.1
-urllib3==1.23; python_version != '3.1.*'


### PR DESCRIPTION
Switch to `pipenv` in S2I config, so we won't need the `requirements.txt` anymore

Related: https://github.com/ManageIQ/aiops-deploy/pull/11, https://github.com/ManageIQ/aiops-data-collector/pull/5, https://github.com/ManageIQ/aiops-publisher/pull/3