### PR TITLE
Enable codecov.io reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,6 @@ install:
   - pipenv sync --dev
 script:
   - pylama
-  - pytest --cov="." --cov-report term-missing
+  - pytest --cov=. --cov-report=xml
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # AI-Ops: Incoming listener microservice
 
 [![Build Status](https://travis-ci.org/ManageIQ/aiops-incoming-listener.svg?branch=master)](https://travis-ci.org/ManageIQ/aiops-incoming-listener)
+[![codecov](https://codecov.io/gh/ManageIQ/aiops-incoming-listener/branch/master/graph/badge.svg)](https://codecov.io/gh/ManageIQ/aiops-incoming-listener)
 [![License](https://img.shields.io/badge/license-APACHE2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
 
 Kafka listener collecting messages containing data relevant to AI-Ops


### PR DESCRIPTION
Add support for Codecov.io bash uploader in TravisCI config.

[Dashboard on Codecov.io](https://codecov.io/gh/ManageIQ/aiops-incoming-listener)
Jira: [AIOPS-106](https://projects.engineering.redhat.com/browse/AIOPS-106)