### PR TITLE
Add `x-rh-identity` to POST request header

### DIFF
--- a/app.py
+++ b/app.py
@@ -59,12 +59,19 @@ async def hit_next(msg_id: str, message: dict) -> aiohttp.ClientResponse:
             'rh_account': message.get('rh_account')
         }
 
+    # b64_identity
+    b64_identity = message.get('b64_identity', '')
+
     # Pass data to the next microservice
     logger.debug('Message %s: forwarding...', msg_id)
     async with aiohttp.ClientSession(raise_for_status=True) as session:
         for attempt in range(MAX_RETRIES):
             try:
-                resp = await session.post(HOST_URL, json=output)
+                resp = await session.post(
+                    HOST_URL,
+                    headers={"x-rh-identity": b64_identity},
+                    json=output
+                )
                 logger.debug('Message %s: sent', msg_id)
                 break
             except aiohttp.ClientError as e:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -34,6 +34,22 @@ class TestHitNext:
         assert request['content']['metadata']['rh_account'] == 'STUB_ACCOUNT'
         assert resp.status == 200
 
+    async def test_forward_b64_identity(self, app, stub_server):
+        """Provide 'b64_identity' in resp.request_info.headers."""
+        resp = await app.hit_next(
+            'STUB_ID',
+            {
+                'url': 'http://STUB.URL',
+                'b64_identity': 'abcde'
+            }
+        )
+
+        request = stub_server['requests'][0]
+
+        assert request['raw'].headers['x-rh-identity'] == 'abcde'
+        assert resp.request_info.headers['x-rh-identity'] == 'abcde'
+        assert resp.status == 200
+
     @pytest.mark.parametrize('app,stub_server', [
         ('INVALID_ENDPOINT', {'status': 404})
     ], indirect=True)


### PR DESCRIPTION
Extract `b64_identity` from the Kafka message and add it to the  POST request header as `x-rh-identity`

https://projects.engineering.redhat.com/browse/AIOPS-96