### PR TITLE
Require b64_identity and check presence of value

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,7 +30,7 @@ GROUP_ID = os.environ.get('KAFKA_CLIENT_GROUP')
 CLIENT_ID = uuid4()
 
 # Properties required to be present in a message
-VALIDATE_PRESENCE = {'url'}
+VALIDATE_PRESENCE = {'url', 'b64_identity'}
 
 # Next micro-service host:port
 NEXT_SERVICE_URL = os.environ.get('NEXT_SERVICE_URL')
@@ -111,7 +111,7 @@ async def process_message(message: ConsumerRecord) -> bool:
     logger.debug('Message %s: %s', msg_id, str(message))
 
     # Select only the interesting messages
-    if not VALIDATE_PRESENCE.issubset(message.keys()):
+    if not all(message.get(k) for k in VALIDATE_PRESENCE):
         return False
 
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,9 @@ async def stub_server(request, aiohttp_server):
     yield output
 
 
-@pytest.fixture(params=(b'{"url":"http://VALID_MESSAGE"}',))
+@pytest.fixture(params=(
+    b'{"url":"http://VALID_MESSAGE","b64_identity":"abcd"}',
+))
 def message(request):
     """Kafka message fixture."""
     return ConsumerRecord(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -103,10 +103,13 @@ class TestProcessMessage:
         b'{"a":"REQUIRED"}',
         b'{"b":"REQUIRED"}',
         b'{"a":"REQUIRED","B":"REQUIRED"}',
+        b'{"a":"REQUIRED","b":""}',
     ), indirect=True)
-    async def test_custom_key_invalid(self, app, message, monkeypatch):
+    async def test_custom_key_invalid(self, app, message, monkeypatch, mocker):
         """Custom `VALIDATE_PRESENCE` settings catches invalid message."""
         monkeypatch.setattr('app.VALIDATE_PRESENCE', {'a', 'b'})
+        mock = mocker.patch('app.hit_next', return_value=Future())
+        mock.return_value.set_result(True)
         success = await app.process_message(message)
 
         assert not success


### PR DESCRIPTION
In CI we've stumbled upon some weird messages produced on Kafka. Listener should be robust enough to overcome these obstacles.

The message in question had bunch of `None` values, including `b64_identity`. When we tried to use this value it failed to encode it as a header...

Here's sample of the message:
```
[2019-04-23 13:13:39,247] DEBUG [consumer.process_message:111] Message #15_142: {'id': None, 'url': '<REDACTED>' , 'service': 'compliance', 'payload_id': '93ec4786a1514be78c502954ea7a92c9', 'account': None, 'principal': None, 'b64_identity': None, 'satellite_managed': None, 'rh_account': None, 'rh_principal': None}
--
  | [2019-04-23 13:13:39,247] DEBUG [consumer.hit_next:66] Message #15_142: forwarding...
  | [2019-04-23 13:13:39,254] ERROR [asyncio.default_exception_handler:1260] Task exception was never retrieved
  | future: <Task finished coro=<process_message() done, defined at app.py:89> exception=TypeError('Cannot serialize non-str key None',)>
  | Traceback (most recent call last):
  | File "app.py", line 118, in process_message
  | await hit_next(msg_id, message)
  | File "app.py", line 73, in hit_next
  | json=output
  | File "/opt/app-root/lib/python3.6/site-packages/aiohttp/client.py", line 495, in _request
  | resp = await req.send(conn)
  | File "/opt/app-root/lib/python3.6/site-packages/aiohttp/client_reqrep.py", line 626, in send
  | await writer.write_headers(status_line, self.headers)
  | File "/opt/app-root/lib/python3.6/site-packages/aiohttp/http_writer.py", line 111, in write_headers
  | buf = _serialize_headers(status_line, headers)
  | File "aiohttp/_http_writer.pyx", line 138, in aiohttp._http_writer._serialize_headers
  | File "aiohttp/_http_writer.pyx", line 110, in aiohttp._http_writer.to_str
  | TypeError: Cannot serialize non-str key None
```

Thsi PR aims to solve this issue by enforcing `b64_identity` to be part of a message and to have a meaningful value.