### PR TITLE
Convert Listener to WSGI Server

### DIFF
--- a/.s2i/environment
+++ b/.s2i/environment
@@ -1,1 +1,2 @@
+APP_CONFIG=config.py
 ENABLE_PIPENV=true

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,8 @@ name = "pypi"
 [packages]
 aiokafka = "*"
 aiohttp = "*"
+flask = "*"
+gunicorn = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ aiokafka = "*"
 aiohttp = "*"
 flask = "*"
 gunicorn = "*"
+prometheus_client = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c7eecbb8aff2a97bb463c749eca4651869c30b2134975d0c6682e63e77a39b46"
+            "sha256": "645113b7e0b33166d9e047ba58bca2e71e37bd01c97a9c9fd6b329ce35f6fa45"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -46,10 +46,10 @@
         },
         "aiokafka": {
             "hashes": [
-                "sha256:d076650bfe0c8de04bec67514d984450ce9b23ca3d5e9f2954bc98cf8e07fa13"
+                "sha256:b11e2284b09cdc59f78b830b5b0344707a673d36a7eb3b7824e537773df30ab4"
             ],
             "index": "pypi",
-            "version": "==0.5.0"
+            "version": "==0.5.2"
         },
         "async-timeout": {
             "hashes": [
@@ -60,10 +60,10 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
-                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
             ],
-            "version": "==18.2.0"
+            "version": "==19.1.0"
         },
         "chardet": {
             "hashes": [
@@ -71,6 +71,29 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "click": {
+            "hashes": [
+                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
+                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+            ],
+            "version": "==7.0"
+        },
+        "flask": {
+            "hashes": [
+                "sha256:13f9f196f330c7c2c5d7a5cf91af894110ca0215ac051b5844701f2bfd934d52",
+                "sha256:45eb5a6fd193d6cf7e0cf5d8a5b31f83d5faae0293695626f539a823e93b13f6"
+            ],
+            "index": "pypi",
+            "version": "==1.1.1"
+        },
+        "gunicorn": {
+            "hashes": [
+                "sha256:aa8e0b40b4157b36a5df5e599f45c9c76d6af43845ba3b3b0efe2c70473c2471",
+                "sha256:fa2662097c66f920f53f70621c6c58ca4a3c4d3434205e608e121b5b3b71f4f3"
+            ],
+            "index": "pypi",
+            "version": "==19.9.0"
         },
         "idna": {
             "hashes": [
@@ -86,12 +109,59 @@
             "markers": "python_version < '3.7'",
             "version": "==1.1.0"
         },
+        "itsdangerous": {
+            "hashes": [
+                "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
+                "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"
+            ],
+            "version": "==1.1.0"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013",
+                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
+            ],
+            "version": "==2.10.1"
+        },
         "kafka-python": {
             "hashes": [
-                "sha256:078acdcd1fc6eddacc46d437c664998b4cf7613b7e79ced66a460965f2648f88",
-                "sha256:0b56f286b674dcb331d80c1d39a01a753cc3acc962bee707da5f207db74f0a26"
+                "sha256:08f83d8e0af2e64d25f94314d4bef6785b34e3b0df0effe9eebf76b98de66eeb",
+                "sha256:3f55bb3e125764a37da550e9fa3d10a85fa09f8af8f8a40f223d2ec8486c2a5b"
             ],
-            "version": "==1.4.3"
+            "version": "==1.4.6"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
+            ],
+            "version": "==1.1.1"
         },
         "multidict": {
             "hashes": [
@@ -129,12 +199,19 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:07b2c978670896022a43c4b915df8958bec4a6b84add7f2c87b2b728bda3ba64",
-                "sha256:f3f0e67e1d42de47b5c67c32c9b26641642e9170fe7e292991793705cd5fef7c",
-                "sha256:fb2cd053238d33a8ec939190f30cfd736c00653a85a2919415cecf7dc3d9da71"
+                "sha256:2ed632b30bb54fc3941c382decfd0ee4148f5c591651c9272473fea2c6397d95",
+                "sha256:b1edbbf0652660e32ae780ac9433f4231e7339c7f9a8057d0f042fcbcea49b87",
+                "sha256:d8179012ec2c620d3791ca6fe2bf7979d979acdbef1fca0bc56b37411db682ed"
             ],
             "markers": "python_version < '3.7'",
-            "version": "==3.7.2"
+            "version": "==3.7.4"
+        },
+        "werkzeug": {
+            "hashes": [
+                "sha256:865856ebb55c4dcd0630cdd8f3331a1847a819dda7e8c750d3db6f2aa6c0209c",
+                "sha256:a0b915f0815982fb2a09161cb8f31708052d0951c3ba433ccc5e1aa276507ca6"
+            ],
+            "version": "==0.15.4"
         },
         "yarl": {
             "hashes": [
@@ -184,10 +261,10 @@
         },
         "astroid": {
             "hashes": [
-                "sha256:35b032003d6a863f5dcd7ec11abd5cd5893428beaa31ab164982403bcb311f22",
-                "sha256:6a5d668d7dc69110de01cdf7aeec69a679ef486862a0850cc0fd5571505b6b7e"
+                "sha256:6560e1e1749f68c64a4b5dee4e091fce798d2f0d84ebe638cf0e0585a343acf4",
+                "sha256:b65db1bbaac9f9f4d190199bb8680af6f6f84fd3769a5ea883df8a91fe68b4c4"
             ],
-            "version": "==2.1.0"
+            "version": "==2.2.5"
         },
         "async-timeout": {
             "hashes": [
@@ -198,11 +275,11 @@
         },
         "asynctest": {
             "hashes": [
-                "sha256:56bd75b03df55956d57437db26700503d1013616314db5d1ea1a73be1186fd71",
-                "sha256:77520850ae21620ec31738f4a7b467acaa44de6d3752d8ac7a9f4dcf55d77853"
+                "sha256:5da6118a7e6d6b54d83a8f7197769d046922a44d2a99c21382f0a6e4fadae676",
+                "sha256:c27862842d15d83e6a34eb0b2866c323880eb3a75e4485b079ea11748fd77fac"
             ],
             "index": "pypi",
-            "version": "==0.12.2"
+            "version": "==0.13.0"
         },
         "atomicwrites": {
             "hashes": [
@@ -213,10 +290,10 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
-                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
             ],
-            "version": "==18.2.0"
+            "version": "==19.1.0"
         },
         "chardet": {
             "hashes": [
@@ -227,40 +304,40 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:09e47c529ff77bf042ecfe858fb55c3e3eb97aac2c87f0349ab5a7efd6b3939f",
-                "sha256:0a1f9b0eb3aa15c990c328535655847b3420231af299386cfe5efc98f9c250fe",
-                "sha256:0cc941b37b8c2ececfed341444a456912e740ecf515d560de58b9a76562d966d",
-                "sha256:10e8af18d1315de936d67775d3a814cc81d0747a1a0312d84e27ae5610e313b0",
-                "sha256:1b4276550b86caa60606bd3572b52769860a81a70754a54acc8ba789ce74d607",
-                "sha256:1e8a2627c48266c7b813975335cfdea58c706fe36f607c97d9392e61502dc79d",
-                "sha256:2b224052bfd801beb7478b03e8a66f3f25ea56ea488922e98903914ac9ac930b",
-                "sha256:447c450a093766744ab53bf1e7063ec82866f27bcb4f4c907da25ad293bba7e3",
-                "sha256:46101fc20c6f6568561cdd15a54018bb42980954b79aa46da8ae6f008066a30e",
-                "sha256:4710dc676bb4b779c4361b54eb308bc84d64a2fa3d78e5f7228921eccce5d815",
-                "sha256:510986f9a280cd05189b42eee2b69fecdf5bf9651d4cd315ea21d24a964a3c36",
-                "sha256:5535dda5739257effef56e49a1c51c71f1d37a6e5607bb25a5eee507c59580d1",
-                "sha256:5a7524042014642b39b1fcae85fb37556c200e64ec90824ae9ecf7b667ccfc14",
-                "sha256:5f55028169ef85e1fa8e4b8b1b91c0b3b0fa3297c4fb22990d46ff01d22c2d6c",
-                "sha256:6694d5573e7790a0e8d3d177d7a416ca5f5c150742ee703f3c18df76260de794",
-                "sha256:6831e1ac20ac52634da606b658b0b2712d26984999c9d93f0c6e59fe62ca741b",
-                "sha256:77f0d9fa5e10d03aa4528436e33423bfa3718b86c646615f04616294c935f840",
-                "sha256:828ad813c7cdc2e71dcf141912c685bfe4b548c0e6d9540db6418b807c345ddd",
-                "sha256:85a06c61598b14b015d4df233d249cd5abfa61084ef5b9f64a48e997fd829a82",
-                "sha256:8cb4febad0f0b26c6f62e1628f2053954ad2c555d67660f28dfb1b0496711952",
-                "sha256:a5c58664b23b248b16b96253880b2868fb34358911400a7ba39d7f6399935389",
-                "sha256:aaa0f296e503cda4bc07566f592cd7a28779d433f3a23c48082af425d6d5a78f",
-                "sha256:ab235d9fe64833f12d1334d29b558aacedfbca2356dfb9691f2d0d38a8a7bfb4",
-                "sha256:b3b0c8f660fae65eac74fbf003f3103769b90012ae7a460863010539bb7a80da",
-                "sha256:bab8e6d510d2ea0f1d14f12642e3f35cefa47a9b2e4c7cea1852b52bc9c49647",
-                "sha256:c45297bbdbc8bb79b02cf41417d63352b70bcb76f1bbb1ee7d47b3e89e42f95d",
-                "sha256:d19bca47c8a01b92640c614a9147b081a1974f69168ecd494687c827109e8f42",
-                "sha256:d64b4340a0c488a9e79b66ec9f9d77d02b99b772c8b8afd46c1294c1d39ca478",
-                "sha256:da969da069a82bbb5300b59161d8d7c8d423bc4ccd3b410a9b4d8932aeefc14b",
-                "sha256:ed02c7539705696ecb7dc9d476d861f3904a8d2b7e894bd418994920935d36bb",
-                "sha256:ee5b8abc35b549012e03a7b1e86c09491457dba6c94112a2482b18589cc2bdb9"
+                "sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9",
+                "sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74",
+                "sha256:3c205bc11cc4fcc57b761c2da73b9b72a59f8d5ca89979afb0c1c6f9e53c7390",
+                "sha256:465ce53a8c0f3a7950dfb836438442f833cf6663d407f37d8c52fe7b6e56d7e8",
+                "sha256:48020e343fc40f72a442c8a1334284620f81295256a6b6ca6d8aa1350c763bbe",
+                "sha256:5296fc86ab612ec12394565c500b412a43b328b3907c0d14358950d06fd83baf",
+                "sha256:5f61bed2f7d9b6a9ab935150a6b23d7f84b8055524e7be7715b6513f3328138e",
+                "sha256:68a43a9f9f83693ce0414d17e019daee7ab3f7113a70c79a3dd4c2f704e4d741",
+                "sha256:6b8033d47fe22506856fe450470ccb1d8ba1ffb8463494a15cfc96392a288c09",
+                "sha256:7ad7536066b28863e5835e8cfeaa794b7fe352d99a8cded9f43d1161be8e9fbd",
+                "sha256:7bacb89ccf4bedb30b277e96e4cc68cd1369ca6841bde7b005191b54d3dd1034",
+                "sha256:839dc7c36501254e14331bcb98b27002aa415e4af7ea039d9009409b9d2d5420",
+                "sha256:8f9a95b66969cdea53ec992ecea5406c5bd99c9221f539bca1e8406b200ae98c",
+                "sha256:932c03d2d565f75961ba1d3cec41ddde00e162c5b46d03f7423edcb807734eab",
+                "sha256:988529edadc49039d205e0aa6ce049c5ccda4acb2d6c3c5c550c17e8c02c05ba",
+                "sha256:998d7e73548fe395eeb294495a04d38942edb66d1fa61eb70418871bc621227e",
+                "sha256:9de60893fb447d1e797f6bf08fdf0dbcda0c1e34c1b06c92bd3a363c0ea8c609",
+                "sha256:9e80d45d0c7fcee54e22771db7f1b0b126fb4a6c0a2e5afa72f66827207ff2f2",
+                "sha256:a545a3dfe5082dc8e8c3eb7f8a2cf4f2870902ff1860bd99b6198cfd1f9d1f49",
+                "sha256:a5d8f29e5ec661143621a8f4de51adfb300d7a476224156a39a392254f70687b",
+                "sha256:aca06bfba4759bbdb09bf52ebb15ae20268ee1f6747417837926fae990ebc41d",
+                "sha256:bb23b7a6fd666e551a3094ab896a57809e010059540ad20acbeec03a154224ce",
+                "sha256:bfd1d0ae7e292105f29d7deaa9d8f2916ed8553ab9d5f39ec65bcf5deadff3f9",
+                "sha256:c62ca0a38958f541a73cf86acdab020c2091631c137bd359c4f5bddde7b75fd4",
+                "sha256:c709d8bda72cf4cd348ccec2a4881f2c5848fd72903c185f363d361b2737f773",
+                "sha256:c968a6aa7e0b56ecbd28531ddf439c2ec103610d3e2bf3b75b813304f8cb7723",
+                "sha256:df785d8cb80539d0b55fd47183264b7002077859028dfe3070cf6359bf8b2d9c",
+                "sha256:f406628ca51e0ae90ae76ea8398677a921b36f0bd71aab2099dfed08abd0322f",
+                "sha256:f46087bbd95ebae244a0eda01a618aff11ec7a069b15a3ef8f6b520db523dcf1",
+                "sha256:f8019c5279eb32360ca03e9fac40a12667715546eed5c5eb59eb381f2f501260",
+                "sha256:fc5f4d209733750afd2714e9109816a29500718b32dd9a5db01c0cb3a019b96a"
             ],
             "index": "pypi",
-            "version": "==4.5.2"
+            "version": "==4.5.3"
         },
         "idna": {
             "hashes": [
@@ -276,47 +353,42 @@
             "markers": "python_version < '3.7'",
             "version": "==1.1.0"
         },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:6dfd58dfe281e8d240937776065dd3624ad5469c835248219bd16cf2e12dbeb7",
+                "sha256:cb6ee23b46173539939964df59d3d72c3e0c1b5d54b84f1d8a7e912fe43612db"
+            ],
+            "version": "==0.18"
+        },
         "isort": {
             "hashes": [
-                "sha256:1153601da39a25b14ddc54955dbbacbb6b2d19135386699e2ad58517953b34af",
-                "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8",
-                "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497"
+                "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1",
+                "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"
             ],
-            "version": "==4.3.4"
+            "version": "==4.3.21"
         },
         "lazy-object-proxy": {
             "hashes": [
-                "sha256:0ce34342b419bd8f018e6666bfef729aec3edf62345a53b537a4dcc115746a33",
-                "sha256:1b668120716eb7ee21d8a38815e5eb3bb8211117d9a90b0f8e21722c0758cc39",
-                "sha256:209615b0fe4624d79e50220ce3310ca1a9445fd8e6d3572a896e7f9146bbf019",
-                "sha256:27bf62cb2b1a2068d443ff7097ee33393f8483b570b475db8ebf7e1cba64f088",
-                "sha256:27ea6fd1c02dcc78172a82fc37fcc0992a94e4cecf53cb6d73f11749825bd98b",
-                "sha256:2c1b21b44ac9beb0fc848d3993924147ba45c4ebc24be19825e57aabbe74a99e",
-                "sha256:2df72ab12046a3496a92476020a1a0abf78b2a7db9ff4dc2036b8dd980203ae6",
-                "sha256:320ffd3de9699d3892048baee45ebfbbf9388a7d65d832d7e580243ade426d2b",
-                "sha256:50e3b9a464d5d08cc5227413db0d1c4707b6172e4d4d915c1c70e4de0bbff1f5",
-                "sha256:5276db7ff62bb7b52f77f1f51ed58850e315154249aceb42e7f4c611f0f847ff",
-                "sha256:61a6cf00dcb1a7f0c773ed4acc509cb636af2d6337a08f362413c76b2b47a8dd",
-                "sha256:6ae6c4cb59f199d8827c5a07546b2ab7e85d262acaccaacd49b62f53f7c456f7",
-                "sha256:7661d401d60d8bf15bb5da39e4dd72f5d764c5aff5a86ef52a042506e3e970ff",
-                "sha256:7bd527f36a605c914efca5d3d014170b2cb184723e423d26b1fb2fd9108e264d",
-                "sha256:7cb54db3535c8686ea12e9535eb087d32421184eacc6939ef15ef50f83a5e7e2",
-                "sha256:7f3a2d740291f7f2c111d86a1c4851b70fb000a6c8883a59660d95ad57b9df35",
-                "sha256:81304b7d8e9c824d058087dcb89144842c8e0dea6d281c031f59f0acf66963d4",
-                "sha256:933947e8b4fbe617a51528b09851685138b49d511af0b6c0da2539115d6d4514",
-                "sha256:94223d7f060301b3a8c09c9b3bc3294b56b2188e7d8179c762a1cda72c979252",
-                "sha256:ab3ca49afcb47058393b0122428358d2fbe0408cf99f1b58b295cfeb4ed39109",
-                "sha256:bd6292f565ca46dee4e737ebcc20742e3b5be2b01556dafe169f6c65d088875f",
-                "sha256:cb924aa3e4a3fb644d0c463cad5bc2572649a6a3f68a7f8e4fbe44aaa6d77e4c",
-                "sha256:d0fc7a286feac9077ec52a927fc9fe8fe2fabab95426722be4c953c9a8bede92",
-                "sha256:ddc34786490a6e4ec0a855d401034cbd1242ef186c20d79d2166d6a4bd449577",
-                "sha256:e34b155e36fa9da7e1b7c738ed7767fc9491a62ec6af70fe9da4a057759edc2d",
-                "sha256:e5b9e8f6bda48460b7b143c3821b21b452cb3a835e6bbd5dd33aa0c8d3f5137d",
-                "sha256:e81ebf6c5ee9684be8f2c87563880f93eedd56dd2b6146d8a725b50b7e5adb0f",
-                "sha256:eb91be369f945f10d3a49f5f9be8b3d0b93a4c2be8f8a5b83b0571b8123e0a7a",
-                "sha256:f460d1ceb0e4a5dcb2a652db0904224f367c9b3c1470d5a7683c0480e582468b"
+                "sha256:159a745e61422217881c4de71f9eafd9d703b93af95618635849fe469a283661",
+                "sha256:23f63c0821cc96a23332e45dfaa83266feff8adc72b9bcaef86c202af765244f",
+                "sha256:3b11be575475db2e8a6e11215f5aa95b9ec14de658628776e10d96fa0b4dac13",
+                "sha256:3f447aff8bc61ca8b42b73304f6a44fa0d915487de144652816f950a3f1ab821",
+                "sha256:4ba73f6089cd9b9478bc0a4fa807b47dbdb8fad1d8f31a0f0a5dbf26a4527a71",
+                "sha256:4f53eadd9932055eac465bd3ca1bd610e4d7141e1278012bd1f28646aebc1d0e",
+                "sha256:64483bd7154580158ea90de5b8e5e6fc29a16a9b4db24f10193f0c1ae3f9d1ea",
+                "sha256:6f72d42b0d04bfee2397aa1862262654b56922c20a9bb66bb76b6f0e5e4f9229",
+                "sha256:7c7f1ec07b227bdc561299fa2328e85000f90179a2f44ea30579d38e037cb3d4",
+                "sha256:7c8b1ba1e15c10b13cad4171cfa77f5bb5ec2580abc5a353907780805ebe158e",
+                "sha256:8559b94b823f85342e10d3d9ca4ba5478168e1ac5658a8a2f18c991ba9c52c20",
+                "sha256:a262c7dfb046f00e12a2bdd1bafaed2408114a89ac414b0af8755c696eb3fc16",
+                "sha256:acce4e3267610c4fdb6632b3886fe3f2f7dd641158a843cf6b6a68e4ce81477b",
+                "sha256:be089bb6b83fac7f29d357b2dc4cf2b8eb8d98fe9d9ff89f9ea6012970a853c7",
+                "sha256:bfab710d859c779f273cc48fb86af38d6e9210f38287df0069a63e40b45a2f5c",
+                "sha256:c10d29019927301d524a22ced72706380de7cfc50f767217485a912b4c8bd82a",
+                "sha256:dd6e2b598849b3d7aee2295ac765a578879830fb8966f70be8cd472e6069932e",
+                "sha256:e408f1eacc0a68fed0c08da45f31d0ebb38079f043328dce69ff133b95c29dc1"
             ],
-            "version": "==1.3.1"
+            "version": "==1.4.1"
         },
         "mccabe": {
             "hashes": [
@@ -327,11 +399,10 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:0125e8f60e9e031347105eb1682cef932f5e97d7b9a1a28d9bf00c22a5daef40",
-                "sha256:590044e3942351a1bdb1de960b739ff4ce277960f2425ad4509446dbace8d9d1"
+                "sha256:3ad685ff8512bf6dc5a8b82ebf73543999b657eded8c11803d9ba6b648986f4d",
+                "sha256:8bb43d1f51ecef60d81854af61a3a880555a14643691cc4b64a6ee269c78f09a"
             ],
-            "markers": "python_version > '2.7'",
-            "version": "==6.0.0"
+            "version": "==7.1.0"
         },
         "multidict": {
             "hashes": [
@@ -367,19 +438,26 @@
             ],
             "version": "==4.5.2"
         },
+        "packaging": {
+            "hashes": [
+                "sha256:0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af",
+                "sha256:9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3"
+            ],
+            "version": "==19.0"
+        },
         "pluggy": {
             "hashes": [
-                "sha256:8ddc32f03971bfdf900a81961a48ccf2fb677cf7715108f85295c67405798616",
-                "sha256:980710797ff6a041e9a73a5787804f848996ecaa6f8a1b1e08224a5894f2074a"
+                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
+                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
             ],
-            "version": "==0.8.1"
+            "version": "==0.12.0"
         },
         "py": {
             "hashes": [
-                "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694",
-                "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"
+                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
+                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
             ],
-            "version": "==1.7.0"
+            "version": "==1.8.0"
         },
         "pycodestyle": {
             "hashes": [
@@ -390,25 +468,23 @@
         },
         "pydocstyle": {
             "hashes": [
-                "sha256:2258f9b0df68b97bf3a6c29003edc5238ff8879f1efb6f1999988d934e432bd8",
-                "sha256:5741c85e408f9e0ddf873611085e819b809fca90b619f5fd7f34bd4959da3dd4",
-                "sha256:ed79d4ec5e92655eccc21eb0c6cf512e69512b4a97d215ace46d17e4990f2039"
+                "sha256:58c421dd605eec0bce65df8b8e5371bb7ae421582cdf0ba8d9435ac5b0ffc36a"
             ],
-            "version": "==3.0.0"
+            "version": "==4.0.0"
         },
         "pyflakes": {
             "hashes": [
-                "sha256:5e8c00e30c464c99e0b501dc160b13a14af7f27d4dffb529c556e30a159e231d",
-                "sha256:f277f9ca3e55de669fba45b7393a1449009cff5a37d1af10ebb76c52765269cd"
+                "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
+                "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
             ],
-            "version": "==2.1.0"
+            "version": "==2.1.1"
         },
         "pylama": {
             "hashes": [
-                "sha256:7e0327ee9b2a350ed73fe54c240894e534e2bccfb23a59ed5ce89f5a5689ee94",
-                "sha256:f81bf3bbd15db802b620903df491e5cd6469dcd542424ce6718425037dcc4d10"
+                "sha256:9bae53ef9c1a431371d6a8dca406816a60d547147b60a4934721898f553b7d8f",
+                "sha256:fd61c11872d6256b019ef1235be37b77c922ef37ac9797df6bd489996dddeb15"
             ],
-            "version": "==7.6.6"
+            "version": "==7.7.1"
         },
         "pylama-pylint": {
             "hashes": [
@@ -420,19 +496,26 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:689de29ae747642ab230c6d37be2b969bf75663176658851f456619aacf27492",
-                "sha256:771467c434d0d9f081741fec1d64dfb011ed26e65e12a28fe06ca2f61c4d556c"
+                "sha256:5d77031694a5fb97ea95e828c8d10fc770a1df6eb3906067aaed42201a8a6a09",
+                "sha256:723e3db49555abaf9bf79dc474c6b9e2935ad82230b10c1138a71ea41ac0fff1"
             ],
             "index": "pypi",
-            "version": "==2.2.2"
+            "version": "==2.3.1"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a",
+                "sha256:9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03"
+            ],
+            "version": "==2.4.0"
         },
         "pytest": {
             "hashes": [
-                "sha256:067a1d4bf827ffdd56ad21bd46674703fce77c5957f6c1eef731f6146bfcef1c",
-                "sha256:9687049d53695ad45cf5fdc7bbd51f0c49f1ea3ecfc4b7f3fde7501b541f17f4"
+                "sha256:6ef6d06de77ce2961156013e9dff62f1b2688aa04d0dc244299fe7d67e09370d",
+                "sha256:a736fed91c12681a7b34617c8fcefe39ea04599ca72c608751c31d89579a3f77"
             ],
             "index": "pypi",
-            "version": "==4.3.0"
+            "version": "==5.0.1"
         },
         "pytest-aiohttp": {
             "hashes": [
@@ -452,19 +535,19 @@
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:0ab664b25c6aa9716cbf203b17ddb301932383046082c081b9848a0edf5add33",
-                "sha256:230ef817450ab0699c6cc3c9c8f7a829c34674456f2ed8df1fe1d39780f7c87f"
+                "sha256:2b097cde81a302e1047331b48cadacf23577e431b61e9c6f49a1170bbe3d3da6",
+                "sha256:e00ea4fdde970725482f1f35630d12f074e121a23801aabf2ae154ec6bdd343a"
             ],
             "index": "pypi",
-            "version": "==2.6.1"
+            "version": "==2.7.1"
         },
         "pytest-mock": {
             "hashes": [
-                "sha256:4d0d06d173eecf172703219a71dbd4ade0e13904e6bbce1ce660e2e0dc78b5c4",
-                "sha256:bfdf02789e3d197bd682a758cae0a4a18706566395fbe2803badcd1335e0173e"
+                "sha256:43ce4e9dd5074993e7c021bb1c22cbb5363e612a2b5a76bc6d956775b10758b7",
+                "sha256:5bf5771b1db93beac965a7347dc81c675ec4090cb841e49d9d34637a25c30568"
             ],
             "index": "pypi",
-            "version": "==1.10.1"
+            "version": "==1.10.4"
         },
         "six": {
             "hashes": [
@@ -475,50 +558,52 @@
         },
         "snowballstemmer": {
             "hashes": [
-                "sha256:919f26a68b2c17a7634da993d91339e288964f93c274f1343e3bbbe2096e1128",
-                "sha256:9f3bcd3c401c3e862ec0ebe6d2c069ebc012ce142cce209c098ccb5b09136e89"
+                "sha256:9f3b9ffe0809d174f7047e121431acf99c89a7040f0ca84f94ba53a498e6d0c9"
             ],
-            "version": "==1.2.1"
+            "version": "==1.9.0"
         },
         "typed-ast": {
             "hashes": [
-                "sha256:035a54ede6ce1380599b2ce57844c6554666522e376bd111eb940fbc7c3dad23",
-                "sha256:037c35f2741ce3a9ac0d55abfcd119133cbd821fffa4461397718287092d9d15",
-                "sha256:049feae7e9f180b64efacbdc36b3af64a00393a47be22fa9cb6794e68d4e73d3",
-                "sha256:19228f7940beafc1ba21a6e8e070e0b0bfd1457902a3a81709762b8b9039b88d",
-                "sha256:2ea681e91e3550a30c2265d2916f40a5f5d89b59469a20f3bad7d07adee0f7a6",
-                "sha256:3a6b0a78af298d82323660df5497bcea0f0a4a25a0b003afd0ce5af049bd1f60",
-                "sha256:5385da8f3b801014504df0852bf83524599df890387a3c2b17b7caa3d78b1773",
-                "sha256:606d8afa07eef77280c2bf84335e24390055b478392e1975f96286d99d0cb424",
-                "sha256:69245b5b23bbf7fb242c9f8f08493e9ecd7711f063259aefffaeb90595d62287",
-                "sha256:6f6d839ab09830d59b7fa8fb6917023d8cb5498ee1f1dbd82d37db78eb76bc99",
-                "sha256:730888475f5ac0e37c1de4bd05eeb799fdb742697867f524dc8a4cd74bcecc23",
-                "sha256:9819b5162ffc121b9e334923c685b0d0826154e41dfe70b2ede2ce29034c71d8",
-                "sha256:9e60ef9426efab601dd9aa120e4ff560f4461cf8442e9c0a2b92548d52800699",
-                "sha256:af5fbdde0690c7da68e841d7fc2632345d570768ea7406a9434446d7b33b0ee1",
-                "sha256:b64efdbdf3bbb1377562c179f167f3bf301251411eb5ac77dec6b7d32bcda463",
-                "sha256:bac5f444c118aeb456fac1b0b5d14c6a71ea2a42069b09c176f75e9bd4c186f6",
-                "sha256:bda9068aafb73859491e13b99b682bd299c1b5fd50644d697533775828a28ee0",
-                "sha256:d659517ca116e6750101a1326107d3479028c5191f0ecee3c7203c50f5b915b0",
-                "sha256:eddd3fb1f3e0f82e5915a899285a39ee34ce18fd25d89582bc89fc9fb16cd2c6"
+                "sha256:18511a0b3e7922276346bcb47e2ef9f38fb90fd31cb9223eed42c85d1312344e",
+                "sha256:262c247a82d005e43b5b7f69aff746370538e176131c32dda9cb0f324d27141e",
+                "sha256:2b907eb046d049bcd9892e3076c7a6456c93a25bebfe554e931620c90e6a25b0",
+                "sha256:354c16e5babd09f5cb0ee000d54cfa38401d8b8891eefa878ac772f827181a3c",
+                "sha256:4e0b70c6fc4d010f8107726af5fd37921b666f5b31d9331f0bd24ad9a088e631",
+                "sha256:630968c5cdee51a11c05a30453f8cd65e0cc1d2ad0d9192819df9978984529f4",
+                "sha256:66480f95b8167c9c5c5c87f32cf437d585937970f3fc24386f313a4c97b44e34",
+                "sha256:71211d26ffd12d63a83e079ff258ac9d56a1376a25bc80b1cdcdf601b855b90b",
+                "sha256:95bd11af7eafc16e829af2d3df510cecfd4387f6453355188342c3e79a2ec87a",
+                "sha256:bc6c7d3fa1325a0c6613512a093bc2a2a15aeec350451cbdf9e1d4bffe3e3233",
+                "sha256:cc34a6f5b426748a507dd5d1de4c1978f2eb5626d51326e43280941206c209e1",
+                "sha256:d755f03c1e4a51e9b24d899561fec4ccaf51f210d52abdf8c07ee2849b212a36",
+                "sha256:d7c45933b1bdfaf9f36c579671fec15d25b06c8398f113dab64c18ed1adda01d",
+                "sha256:d896919306dd0aa22d0132f62a1b78d11aaf4c9fc5b3410d3c666b818191630a",
+                "sha256:ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12"
             ],
-            "markers": "python_version < '3.7' and implementation_name == 'cpython'",
-            "version": "==1.3.1"
+            "markers": "implementation_name == 'cpython'",
+            "version": "==1.4.0"
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:07b2c978670896022a43c4b915df8958bec4a6b84add7f2c87b2b728bda3ba64",
-                "sha256:f3f0e67e1d42de47b5c67c32c9b26641642e9170fe7e292991793705cd5fef7c",
-                "sha256:fb2cd053238d33a8ec939190f30cfd736c00653a85a2919415cecf7dc3d9da71"
+                "sha256:2ed632b30bb54fc3941c382decfd0ee4148f5c591651c9272473fea2c6397d95",
+                "sha256:b1edbbf0652660e32ae780ac9433f4231e7339c7f9a8057d0f042fcbcea49b87",
+                "sha256:d8179012ec2c620d3791ca6fe2bf7979d979acdbef1fca0bc56b37411db682ed"
             ],
             "markers": "python_version < '3.7'",
-            "version": "==3.7.2"
+            "version": "==3.7.4"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
+                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
+            ],
+            "version": "==0.1.7"
         },
         "wrapt": {
             "hashes": [
-                "sha256:4aea003270831cceb8a90ff27c4031da6ead7ec1886023b80ce0dfe0adf61533"
+                "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
             ],
-            "version": "==1.11.1"
+            "version": "==1.11.2"
         },
         "yarl": {
             "hashes": [
@@ -535,6 +620,13 @@
                 "sha256:e060906c0c585565c718d1c3841747b61c5439af2211e185f6739a9412dfbde1"
             ],
             "version": "==1.3.0"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:4970c3758f4e89a7857a973b1e2a5d75bcdc47794442f2e2dd4fe8e0466e809a",
+                "sha256:8a5712cfd3bb4248015eb3b0b3c54a5f6ee3f2425963ef2a0125b8bc40aafaec"
+            ],
+            "version": "==0.5.2"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "645113b7e0b33166d9e047ba58bca2e71e37bd01c97a9c9fd6b329ce35f6fa45"
+            "sha256": "32992325c32c7bcedd43be91d7462f42cd72aaceed98c03222419125cf4e7a42"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -196,6 +196,13 @@
                 "sha256:db603a1c235d110c860d5f39988ebc8218ee028f07a7cbc056ba6424372ca31b"
             ],
             "version": "==4.5.2"
+        },
+        "prometheus-client": {
+            "hashes": [
+                "sha256:71cd24a2b3eb335cb800c7159f423df1bd4dcd5171b234be15e3f31ec9f622da"
+            ],
+            "index": "pypi",
+            "version": "==0.7.1"
         },
         "typing-extensions": {
             "hashes": [

--- a/config.py
+++ b/config.py
@@ -1,0 +1,9 @@
+import os
+
+# pylama:ignore=C0103
+bind = '127.0.0.1:8000'
+
+workers = int(os.environ.get('GUNICORN_PROCESSES', '1'))
+
+forwarded_allow_ips = '*'
+secure_scheme_headers = {'X-Forwarded-Proto': 'https'}

--- a/kafka_app.py
+++ b/kafka_app.py
@@ -8,6 +8,8 @@ import asyncio
 import aiohttp
 from aiokafka import AIOKafkaConsumer, ConsumerRecord
 
+import prometheus_metrics
+
 # Setup logging
 logging.basicConfig(
     level=logging.WARNING,
@@ -123,6 +125,7 @@ async def process_message(message: ConsumerRecord) -> bool:
         return False
 
     logger.info('Message %s: Done', msg_id)
+    prometheus_metrics.METRICS['processed_messages_total'].inc()
     return True
 
 
@@ -161,6 +164,11 @@ async def consume_messages() -> None:
 
     finally:
         await consumer.stop()
+
+
+def metrics():
+    """Metrics function."""
+    return prometheus_metrics.generate_aggregated_metrics()
 
 
 def main():

--- a/kafka_app.py
+++ b/kafka_app.py
@@ -162,7 +162,7 @@ async def consume_messages() -> None:
 
 def main():
     """Service init function."""
-    if __name__ == '__main__':
+    if __name__ == 'kafka_app':
         # Check environment variables passed to container
         # pylama:ignore=C0103
         env = {'KAFKA_SERVER', 'KAFKA_TOPIC', 'NEXT_SERVICE_URL'}
@@ -176,6 +176,3 @@ def main():
 
         # Run the consumer
         MAIN_LOOP.run_until_complete(consume_messages())
-
-
-main()

--- a/kafka_app.py
+++ b/kafka_app.py
@@ -38,7 +38,14 @@ VALIDATE_PRESENCE = {'url', 'b64_identity'}
 NEXT_SERVICE_URL = os.environ.get('NEXT_SERVICE_URL')
 MAX_RETRIES = 3
 
-KAFKA_RESOURCES = {}
+KAFKA_CLIENT = None
+
+
+# W0212 Access to a protected member _conns of a client class [pylint]
+# pylint: disable=W0212
+
+# W0603 Using the global statement [pylint]
+# pylint: disable=W0603
 
 
 async def hit_next(msg_id: str, message: dict) -> aiohttp.ClientResponse:
@@ -153,7 +160,10 @@ async def consume_messages() -> None:
 
     # Get cluster layout, subscribe to group
     await consumer.start()
-    KAFKA_RESOURCES['consumer'] = consumer
+
+    global KAFKA_CLIENT
+    KAFKA_CLIENT = consumer._client
+
     logger.info('Consumer subscribed and active!')
 
     # Start consuming messages

--- a/kafka_app.py
+++ b/kafka_app.py
@@ -36,6 +36,8 @@ VALIDATE_PRESENCE = {'url', 'b64_identity'}
 NEXT_SERVICE_URL = os.environ.get('NEXT_SERVICE_URL')
 MAX_RETRIES = 3
 
+KAFKA_RESOURCES = {}
+
 
 async def hit_next(msg_id: str, message: dict) -> aiohttp.ClientResponse:
     """Send message as JSON to the HOST via HTTP Post.
@@ -148,6 +150,7 @@ async def consume_messages() -> None:
 
     # Get cluster layout, subscribe to group
     await consumer.start()
+    KAFKA_RESOURCES['consumer'] = consumer
     logger.info('Consumer subscribed and active!')
 
     # Start consuming messages

--- a/kafka_app.py
+++ b/kafka_app.py
@@ -41,13 +41,6 @@ MAX_RETRIES = 3
 KAFKA_CLIENT = None
 
 
-# W0212 Access to a protected member _conns of a client class [pylint]
-# pylint: disable=W0212
-
-# W0603 Using the global statement [pylint]
-# pylint: disable=W0603
-
-
 async def hit_next(msg_id: str, message: dict) -> aiohttp.ClientResponse:
     """Send message as JSON to the HOST via HTTP Post.
 
@@ -161,6 +154,11 @@ async def consume_messages() -> None:
     # Get cluster layout, subscribe to group
     await consumer.start()
 
+    # W0212 Access to a protected member _conns of a client class [pylint]
+    # pylint: disable=W0212
+
+    # W0603 Using the global statement [pylint]
+    # pylint: disable=W0603
     global KAFKA_CLIENT
     KAFKA_CLIENT = consumer._client
 

--- a/prometheus_metrics/__init__.py
+++ b/prometheus_metrics/__init__.py
@@ -1,0 +1,5 @@
+"""Metrics interface."""
+
+from .prometheus_metrics import generate_aggregated_metrics, METRICS
+
+__all__ = ["generate_aggregated_metrics", "METRICS"]

--- a/prometheus_metrics/prometheus_metrics.py
+++ b/prometheus_metrics/prometheus_metrics.py
@@ -1,0 +1,17 @@
+from prometheus_client import (Counter, generate_latest,
+                               CollectorRegistry, multiprocess)
+
+# Prometheus Metrics
+METRICS = {
+    'processed_messages_total': Counter(
+        'aiops_incoming_listener_processed_messages_total',
+        'The total number of messages successfully processed'
+    ),
+}
+
+
+def generate_aggregated_metrics():
+    """Generate Aggregated Metrics for multiple processes."""
+    registry = CollectorRegistry()
+    multiprocess.MultiProcessCollector(registry)
+    return generate_latest(registry)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,7 @@ async def stub_server(request, aiohttp_server):
 def message(request):
     """Kafka message fixture."""
     return ConsumerRecord(
-        'topic', 0, 0, datetime.now(), '', '', request.param, '', '', ''
+        'topic', 0, 0, datetime.now(), '', '', request.param, '', '', '', ()
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from aiohttp import web
 from aiokafka import ConsumerRecord
 import asynctest
 
-import app as original_app
+import kafka_app as original_app
 
 
 @pytest.fixture
@@ -24,7 +24,7 @@ def app(request, monkeypatch):
     # Setup new asyncio loop
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    monkeypatch.setattr('app.MAIN_LOOP', loop)
+    monkeypatch.setattr('kafka_app.MAIN_LOOP', loop)
 
     # Reload app module to propagate env. changes
     reload(original_app)
@@ -82,7 +82,7 @@ def kafka_consumer(request, mocker):
     - stop()
     - consumed message list (taken from `request.param`)
     """
-    consumer = mocker.patch('app.AIOKafkaConsumer',
+    consumer = mocker.patch('kafka_app.AIOKafkaConsumer',
                             new_callable=asynctest.MagicMock)
 
     f_start = asyncio.Future()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,3 +94,10 @@ def kafka_consumer(request, mocker):
     f_stop.set_result(True)
 
     yield consumer
+
+
+@pytest.fixture()
+async def kafka_consumer_start():
+    """Mock AIOKafkaConsumer as Subscribed and Active."""
+    await original_app.consume_messages()
+    return True

--- a/tests/test_kafka_app.py
+++ b/tests/test_kafka_app.py
@@ -92,7 +92,7 @@ class TestProcessMessage:
 
     async def test_valid_message(self, app, message, mocker):
         """Ensure that a valid message can be processed."""
-        mock = mocker.patch('app.hit_next', return_value=Future())
+        mock = mocker.patch('kafka_app.hit_next', return_value=Future())
         mock.return_value.set_result(True)
         success = await app.process_message(message)
 
@@ -107,8 +107,8 @@ class TestProcessMessage:
     ), indirect=True)
     async def test_custom_key_invalid(self, app, message, monkeypatch, mocker):
         """Custom `VALIDATE_PRESENCE` settings catches invalid message."""
-        monkeypatch.setattr('app.VALIDATE_PRESENCE', {'a', 'b'})
-        mock = mocker.patch('app.hit_next', return_value=Future())
+        monkeypatch.setattr('kafka_app.VALIDATE_PRESENCE', {'a', 'b'})
+        mock = mocker.patch('kafka_app.hit_next', return_value=Future())
         mock.return_value.set_result(True)
         success = await app.process_message(message)
 
@@ -119,8 +119,8 @@ class TestProcessMessage:
     ), indirect=True)
     async def test_custom_key_valid(self, app, message, monkeypatch, mocker):
         """Custom `VALIDATE_PRESENCE` settings works for a valid message."""
-        monkeypatch.setattr('app.VALIDATE_PRESENCE', {'a', 'b'})
-        mock = mocker.patch('app.hit_next', return_value=Future())
+        monkeypatch.setattr('kafka_app.VALIDATE_PRESENCE', {'a', 'b'})
+        mock = mocker.patch('kafka_app.hit_next', return_value=Future())
         mock.return_value.set_result(True)
         success = await app.process_message(message)
 
@@ -128,7 +128,7 @@ class TestProcessMessage:
 
     async def test_unable_to_hit_next(self, app, message, mocker):
         """Test when unable to pass message to next service."""
-        mocker.patch('app.hit_next', side_effect=ClientError())
+        mocker.patch('kafka_app.hit_next', side_effect=ClientError())
         success = await app.process_message(message)
 
         assert not success
@@ -154,7 +154,7 @@ class TestConsumeMessages:
         """Check if given amount of messages is really consumed."""
         # pylama:ignore=W0613
 
-        mock = mocker.patch('app.process_message', return_value=Future())
+        mock = mocker.patch('kafka_app.process_message', return_value=Future())
         mock.return_value.set_result(True)
 
         await app.consume_messages()
@@ -162,7 +162,7 @@ class TestConsumeMessages:
 
     async def test_multiple_topics(self, app, kafka_consumer, monkeypatch):
         """Test that multiple topic are propagated to Kafka."""
-        monkeypatch.setattr('app.TOPIC', ['A_TOPIC', 'B_TOPIC'])
+        monkeypatch.setattr('kafka_app.TOPIC', ['A_TOPIC', 'B_TOPIC'])
         await app.consume_messages()
 
         assert kafka_consumer.call_args[0][0] == ['A_TOPIC', 'B_TOPIC']
@@ -176,7 +176,7 @@ class TestMain:
     ))
     def test_missing_env_variables(self, app, mocker, monkeypatch, variable):
         """Should exit when required env variable is missing."""
-        mocker.patch.object(app, '__name__', '__main__')
+        mocker.patch.object(app, '__name__', 'kafka_app')
         monkeypatch.delenv(variable)
 
         with pytest.raises(SystemExit) as err:
@@ -186,10 +186,10 @@ class TestMain:
 
     def test_consumer_started(self, app, mocker):
         """Check that event loop was started when env is OK."""
-        mocker.patch.object(app, '__name__', '__main__')
-        mock_consumer = mocker.patch('app.consume_messages')
+        mocker.patch.object(app, '__name__', 'kafka_app')
+        mock_consumer = mocker.patch('kafka_app.consume_messages')
         mock_consumer.return_value = Future()
-        mock_loop = mocker.patch('app.MAIN_LOOP')
+        mock_loop = mocker.patch('kafka_app.MAIN_LOOP')
 
         app.main()
 

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -1,0 +1,60 @@
+import wsgi
+
+# R0201 = Method could be a function Used when a method doesn't use its bound
+# instance, and so could be written as a function.
+# R0903 = Too few public methods
+# W0212 = Access to a protected member of a client class
+
+# pylint: disable=R0201,R0903,W0212
+
+
+class TestGetRoot:
+    """Test various use cases for the index route."""
+
+    def test_route_with_consumer_started(self, mocker, app, kafka_consumer,
+                                         kafka_consumer_start):
+        """Test index route when consumer is subscribed."""
+        client = wsgi.application.test_client(mocker)
+
+        url = '/'
+
+        response = client.get(url)
+
+        output = {
+            "message": "Listener Up and Running",
+            "status": "OK"
+        }
+
+        assert app.__name__ == 'kafka_app'
+        kafka_consumer.assert_called_once()
+        assert kafka_consumer_start
+
+        assert response.get_json() == output
+        assert response.status_code == 200
+
+    def test_route_with_consumer_not_started(self, app, mocker):
+        """Test index route when consumer is not available."""
+        client = wsgi.application.test_client(mocker)
+
+        url = '/'
+
+        response = client.get(url)
+
+        output = {
+            "message": "Listener Down",
+            "status": "Error"
+        }
+
+        assert app.__name__ == 'kafka_app'
+        assert response.get_json() == output
+        assert response.status_code == 500
+
+    def test_route_with_metrics(self, mocker):
+        """Basic test for metrics route."""
+        client = wsgi.application.test_client(mocker)
+
+        url = '/metrics'
+
+        response = client.get(url)
+
+        assert response.status_code == 200

--- a/wsgi.py
+++ b/wsgi.py
@@ -2,12 +2,16 @@ import logging
 import os
 import threading
 
-from flask import Flask
+from flask import Flask, jsonify
 
 import kafka_app as APP
 
 
 gunicorn_logger = logging.getLogger('gunicorn.error')
+
+
+# W0212 Access to a protected member _conns of a client class [pylint]
+# pylint: disable=W0212
 
 
 def create_application():
@@ -20,6 +24,21 @@ def create_application():
 
 
 application = create_application()
+
+
+@application.route("/", methods=['GET'])
+def get_root():
+    """Root Endpoint."""
+    if APP.KAFKA_RESOURCES.get('consumer') and \
+            APP.KAFKA_RESOURCES.get('consumer')._client._conns:
+        return jsonify(
+            status='OK',
+            message='Listener Up and Running'
+        )
+    return jsonify(
+        status='Error',
+        message='Listener Down'
+    ), 500
 
 
 if __name__ == '__main__':

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,28 @@
+import logging
+import os
+import threading
+
+from flask import Flask
+
+import kafka_app as APP
+
+
+gunicorn_logger = logging.getLogger('gunicorn.error')
+
+
+def create_application():
+    """Create App."""
+    app = Flask(__name__)
+    thread = threading.Thread(target=APP.main)
+    thread.start()
+
+    return app
+
+
+application = create_application()
+
+
+if __name__ == '__main__':
+    # pylama:ignore=C0103
+    port = os.environ.get("PORT", 8004)
+    application.run(port=int(port))

--- a/wsgi.py
+++ b/wsgi.py
@@ -48,8 +48,8 @@ application = create_application()
 @application.route("/", methods=['GET'])
 def get_root():
     """Root Endpoint."""
-    if APP.KAFKA_RESOURCES.get('consumer') and \
-            APP.KAFKA_RESOURCES.get('consumer')._client._conns:
+    kafka_client = APP.KAFKA_CLIENT
+    if kafka_client and kafka_client._conns:
         return jsonify(
             status='OK',
             message='Listener Up and Running'


### PR DESCRIPTION
From time to time over the last few months, we have discussed the inability of incoming-listener to scrape metrics. The primary reason for this inability is because the incoming listener is not a server, and hence cannot serve the `/metrics` endpoint. More recently, this topic also came up in the context of liveness/readiness for incoming-listener. 
Since we keep hitting this shortcoming in incoming-listener many times for one reason or the other, I think it's in our best interest to make it behave like rest of the services, so essentially, convert it into a server.

The first commit 10eb381 makes bare minimum changes to convert the listener service to a gunicorn wsgi service, and aims to keep things really simple, while preserving the original code as much as possible.
I have successfully tested this in OpenShift, and it seems to work pretty well!

The other 2 commits simply add 2 routes - 
- an index route for liveness/readiness where we simply check if the Kafka Consumer client has active `connections` (this was successfully tested locally in both scenarios - with connection/and without connection)
- a `metrics` route that can show us the scraped metrics (currently there is only 1 metric, we should add more)

Output of the 2 endpoints in an OpenShift pod -

```
(app-root) sh-4.2$ curl http://aiops-incoming-listener:8080
{"message":"Listener Up and Running","status":"OK"}
(app-root) sh-4.2$
(app-root) sh-4.2$
(app-root) sh-4.2$ curl http://aiops-incoming-listener:8080/metrics
# HELP aiops_incoming_listener_processed_messages_total Multiprocess metric
# TYPE aiops_incoming_listener_processed_messages_total counter
aiops_incoming_listener_processed_messages_total 3.0
(app-root) sh-4.2$
```

Pending items:
- [ ] More metrics
- [ ] Tests for wsgi
(to be implemented if we go with this approach)